### PR TITLE
Allow override of 'version' and 'ignore' properties in bower.json. Allow to specify another 'bowerFile' path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,21 @@ It's super simple stuff, and I hope some people might find it useful!
 2. `packageName` -- The bower package name. This overrides `name` in `bower.json`
 3. `stageDir` -- A staging directory where the repository is built and tagged.
 4. `main` -- Enables the grunt task to override `bower.json`'s `main` parameter. This will be ignored if it is not a string or an array.
-5. `version` -- (Optional) Override `version` in `bower.json`
-6. `ignore` -- (Optional) Extend ignored files in `bower.json`. This will be ignored if it is not an array.
-7. `dependencies` -- (Optional) Enables the grunt task to add dependencies to a build.
-8. `extendDependencies` -- (Optional) If true, the dependencies from the source repository will be extended with the grunt options dependencies.
-9. `keepDevDependencies` -- (Optional) By default devDependencies are removed. Set this to true to keep them.
-10. `branchName` -- (Optional) Specify the branch used for the endpoint.
-11. `overwriteTag` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for `Bower`.
+5. `bowerFile` -- (Optional) The path to bower.json file. Default is `bower.json` at the root of project.
+6. `version` -- (Optional) Override `version` in `bower.json`.
+7. `ignore` -- (Optional) Extend ignored files in `bower.json`. This will be ignored if it is not an array.
+8. `dependencies` -- (Optional) Enables the grunt task to add dependencies to a build.
+9. `extendDependencies` -- (Optional) If true, the dependencies from the source repository will be extended with the grunt options dependencies.
+10. `keepDevDependencies` -- (Optional) By default devDependencies are removed. Set this to true to keep them.
+11. `branchName` -- (Optional) Specify the branch used for the endpoint.
+12. `overwriteTag` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for `Bower`.
 A tag name is derived from the `version` attribute in `bower.json`. If you have already released a certain version of a package and attempt to do overwrite that version,
 the plug-in will fail, because it won't be able to push the same tag twice. The option ensures that a tag is deleted, before it gets pushed again.
-12. `removeVersionTags` -- (Optional) If true, all Git tags whose name starts with a value of `version` in `bower.json` will be removed.
-13. `suffixTagWithTimestamp` -- (Optional) If true, a Git tag will be suffixed with `+[CURRENT_TIMESTAMP]`, e.g. `1.0.0-SNAPSHOT+849829134829`
+13. `removeVersionTags` -- (Optional) If true, all Git tags whose name starts with a value of `version` in `bower.json` will be removed.
+14. `suffixTagWithTimestamp` -- (Optional) If true, a Git tag will be suffixed with `+[CURRENT_TIMESTAMP]`, e.g. `1.0.0-SNAPSHOT+849829134829`
+15. `push` -- (Optional) If false, does not push to remote.
+16. `createTags` -- (Optional) If false, does not create tag for published version.
+17. `debug` -- (Optional) If true, the stageDir is not removed after publish.
 
 ## Files
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,16 @@ It's super simple stuff, and I hope some people might find it useful!
 2. `packageName` -- The bower package name. This overrides `name` in `bower.json`
 3. `stageDir` -- A staging directory where the repository is built and tagged.
 4. `main` -- Enables the grunt task to override `bower.json`'s `main` parameter. This will be ignored if it is not a string or an array.
-5. `dependencies` -- Enables the grunt task to add dependencies to a build.
-6. `extendDependencies` -- If true, the dependencies from the source repository will be extended with the grunt options dependencies.
-7. `branchName` -- (Optional) Specify the branch used for the endpoint.
-8. ```overwriteTag``` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for ```Bower```.
-A tag name is derived from the ```version``` attribute in ```bower.json```. If you have already released a certain version of a package and attempt to do overwrite that version,
+5. `version` -- Override `version` in `bower.json`
+6. `ignore` -- Extend ignored files in `bower.json`. This will be ignored if it is not an array.
+7. `dependencies` -- Enables the grunt task to add dependencies to a build.
+8. `extendDependencies` -- If true, the dependencies from the source repository will be extended with the grunt options dependencies.
+9. `branchName` -- (Optional) Specify the branch used for the endpoint.
+10. `overwriteTag` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for `Bower`.
+A tag name is derived from the `version` attribute in `bower.json`. If you have already released a certain version of a package and attempt to do overwrite that version,
 the plug-in will fail, because it won't be able to push the same tag twice. The option ensures that a tag is deleted, before it gets pushed again.
-9. ```removeVersionTags``` -- (Optional) If true, all Git tags whose name starts with a value of ```version``` in ```bower.json``` will be removed.
-10. ```suffixTagWithTimestamp``` -- (Optional) If true, a Git tag will be suffixed with ```+[CURRENT_TIMESTAMP]```, e.g. ```1.0.0-SNAPSHOT+849829134829```
+11. `removeVersionTags` -- (Optional) If true, all Git tags whose name starts with a value of `version` in `bower.json` will be removed.
+12. `suffixTagWithTimestamp` -- (Optional) If true, a Git tag will be suffixed with `+[CURRENT_TIMESTAMP]`, e.g. `1.0.0-SNAPSHOT+849829134829`
 
 ## Files
 
@@ -96,8 +98,8 @@ They may be specified as per the guidelines in [Configuring files](http://gruntj
 ## Releasing Snapshot Version
 
 In some development environments developers prefer to have a snapshot version, which indicates a work in progress. The plug-in allows releasing snapshot versions.
-All you have to do is to set ```removeVersionTags``` and ```suffixTagWithTimestamp``` to ```true```.
-Those options will ensure that typing ```bower update``` will fetch a new version of a snapshot dependency without having to change ```bower.json``` or clean bower cache.
+All you have to do is to set `removeVersionTags` and `suffixTagWithTimestamp` to `true`.
+Those options will ensure that typing `bower update` will fetch a new version of a snapshot dependency without having to change `bower.json` or clean bower cache.
 
 ##License
 

--- a/README.md
+++ b/README.md
@@ -78,16 +78,17 @@ It's super simple stuff, and I hope some people might find it useful!
 2. `packageName` -- The bower package name. This overrides `name` in `bower.json`
 3. `stageDir` -- A staging directory where the repository is built and tagged.
 4. `main` -- Enables the grunt task to override `bower.json`'s `main` parameter. This will be ignored if it is not a string or an array.
-5. `version` -- Override `version` in `bower.json`
-6. `ignore` -- Extend ignored files in `bower.json`. This will be ignored if it is not an array.
-7. `dependencies` -- Enables the grunt task to add dependencies to a build.
-8. `extendDependencies` -- If true, the dependencies from the source repository will be extended with the grunt options dependencies.
-9. `branchName` -- (Optional) Specify the branch used for the endpoint.
-10. `overwriteTag` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for `Bower`.
+5. `version` -- (Optional) Override `version` in `bower.json`
+6. `ignore` -- (Optional) Extend ignored files in `bower.json`. This will be ignored if it is not an array.
+7. `dependencies` -- (Optional) Enables the grunt task to add dependencies to a build.
+8. `extendDependencies` -- (Optional) If true, the dependencies from the source repository will be extended with the grunt options dependencies.
+9. `keepDevDependencies` -- (Optional) By default devDependencies are removed. Set this to true to keep them.
+10. `branchName` -- (Optional) Specify the branch used for the endpoint.
+11. `overwriteTag` -- (Optional) If true, a Git tag will be overwritten. The plug-in creates a Git tag in order to specify a package version for `Bower`.
 A tag name is derived from the `version` attribute in `bower.json`. If you have already released a certain version of a package and attempt to do overwrite that version,
 the plug-in will fail, because it won't be able to push the same tag twice. The option ensures that a tag is deleted, before it gets pushed again.
-11. `removeVersionTags` -- (Optional) If true, all Git tags whose name starts with a value of `version` in `bower.json` will be removed.
-12. `suffixTagWithTimestamp` -- (Optional) If true, a Git tag will be suffixed with `+[CURRENT_TIMESTAMP]`, e.g. `1.0.0-SNAPSHOT+849829134829`
+12. `removeVersionTags` -- (Optional) If true, all Git tags whose name starts with a value of `version` in `bower.json` will be removed.
+13. `suffixTagWithTimestamp` -- (Optional) If true, a Git tag will be suffixed with `+[CURRENT_TIMESTAMP]`, e.g. `1.0.0-SNAPSHOT+849829134829`
 
 ## Files
 

--- a/tasks/bower-release.js
+++ b/tasks/bower-release.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
   var endpoints = {
     git: injector.instantiate(Git),
     test: injector.instantiate(Test)
-  }
+  };
 
   grunt.registerMultiTask('bowerRelease',
     'Push bower component files to git endpoint and publish', function() {
@@ -80,10 +80,16 @@ module.exports = function(grunt) {
     }
 
     /* Read Bower configuration */
-    ['bower.json', 'component.json'].forEach(function (configFile) {
+    var configFiles = ['bower.json', 'component.json'];
+
+    if(options.bowerFile) {
+      configFiles.unshift(options.bowerFile);
+    }
+
+    configFiles.forEach(function (configFile) {
       if (!bowerJSON && grunt.file.isFile(configFile)) {
         bowerJSON = grunt.file.readJSON(configFile);
-        bowerFile = configFile;
+        bowerFile = path.basename(configFile);
       }
     });
 
@@ -259,7 +265,7 @@ module.exports = function(grunt) {
       function getExpandedStageDest (item) {
         var stageFile = grunt.file.expandMapping([item.dest], options.stageDir, {
           cwd: item.orig.cwd || startDir
-        })
+        });
         return stageFile[0].dest;
       }
 
@@ -359,7 +365,7 @@ module.exports = function(grunt) {
           /* After committing/tagging the release, push to the server */
           endpoint.push(options.branchName, tag, options.forcePush, pushed);
         } else {
-          grunt.log.writeln('Skipping remote push!')
+          grunt.log.writeln('Skipping remote push!');
           finish();
         }
       }
@@ -390,5 +396,4 @@ module.exports = function(grunt) {
       }
     }
  })
-}
-
+};

--- a/tasks/bower-release.js
+++ b/tasks/bower-release.js
@@ -145,7 +145,12 @@ module.exports = function(grunt) {
       delete bowerJSON.devDependencies;
     }
 
-    /* Override private option */
+    // Extend ignores
+    if (typeof options.ignore === 'array') {
+      bowerJSON.ignore = grunt.util._.union(bowerJSON.ignore || [], options.ignore || []);
+    }
+
+      /* Override private option */
     delete bowerJSON.private;
     if ( typeof options.private === 'boolean' ) {
       bowerJSON.private = options.private;

--- a/tasks/bower-release.js
+++ b/tasks/bower-release.js
@@ -124,6 +124,11 @@ module.exports = function(grunt) {
       bowerJSON.main = options.main
     }
 
+    /* Override version */
+    if (typeof options.version === 'string') {
+      bowerJSON.version = options.version
+    }
+
     /* Override or extend dependencies */
     var dependencies = {};
 
@@ -145,12 +150,12 @@ module.exports = function(grunt) {
       delete bowerJSON.devDependencies;
     }
 
-    // Extend ignores
+    /* Extend ignores */
     if (typeof options.ignore === 'array') {
       bowerJSON.ignore = grunt.util._.union(bowerJSON.ignore || [], options.ignore || []);
     }
 
-      /* Override private option */
+    /* Override private option */
     delete bowerJSON.private;
     if ( typeof options.private === 'boolean' ) {
       bowerJSON.private = options.private;

--- a/tasks/bower-release.js
+++ b/tasks/bower-release.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
 
     /* Fail if we don't have an endpoint */
     if (typeof options.endpoint === 'undefined') {
-      return finish(new Error('Missing required \'endpoint\' parameter'))
+      return finish(new Error("Missing required 'endpoint' parameter"))
     }
 
     bowerJSON.endpoint = options.endpoint;
@@ -124,6 +124,7 @@ module.exports = function(grunt) {
       bowerJSON.main = options.main
     }
 
+    /* Override or extend dependencies */
     var dependencies = {};
 
     if (options.extendDependencies == true) {
@@ -139,7 +140,16 @@ module.exports = function(grunt) {
       bowerJSON.dependencies = grunt.util._.extend(dependencies || {}, options.dependencies || {});
     }
 
-    /* TODO: Support devDependency overriding? Is that really needed? */
+    /* By default remove dev dependencies */
+    if ( !( typeof options.keepDevDependencies === 'boolean' && options.keepDevDependencies === true ) ) {
+      delete bowerJSON.devDependencies;
+    }
+
+    /* Override private option */
+    delete bowerJSON.private;
+    if ( typeof options.private === 'boolean' ) {
+      bowerJSON.private = options.private;
+    }
 
     /* For now, 'git' is the only supported endpoint type, and we aren't doing anything
      * complicated to figure out the correct VCS or protocol. So just assume 'git'

--- a/tasks/endpoints/git.js
+++ b/tasks/endpoints/git.js
@@ -124,20 +124,20 @@ function Git(grunt, async) {
       gitExec(args, streams, done);
     },
 
-    /* Push the changesets to the server */
+    /* Push the tags and changesets to the server */
     push: function(branch, tag, force, done) {
       var args = [];
 
       args.push('push');
       args.push('origin');
-      if(typeof branch === 'string') {
-        args.push(branch);
-      }
       if (typeof tag === 'string') {
-        args.push(tag);
+        args.push('--follow-tags');
       }
       if (force) {
         args.push('--force');
+      }
+      if(typeof branch === 'string') {
+        args.push(branch);
       }
 
       gitExec(args, streams, done);
@@ -145,7 +145,7 @@ function Git(grunt, async) {
   };
 
   function gitExec(args, stdio, done) {
-    grunt.verbose.writeln('git ' + args.join(' '));
+    grunt.verbose.writeln('Executing command: git ' + args.join(' '));
     grunt.util.spawn({
       cmd: 'git',
       args: args,


### PR DESCRIPTION
More options if you have a bower.json template that is dynamically reused for sub-component releases.
